### PR TITLE
fixed the bug of documents repetation

### DIFF
--- a/src/controllers/sorting.ts
+++ b/src/controllers/sorting.ts
@@ -18,7 +18,7 @@
 			return { "delivery.time": 1 };
 
 		default:
-			return { createdAt: -1 };
+			return {};
 	}
 };
 


### PR DESCRIPTION
PR: Fixed duplicate documents issue

Reason of issue: At the default case of sorting, we are sorting based on createdAt. So there could be multiple items with createdAt causing the issue.

Solution: Passed {} as default case
